### PR TITLE
Compass Injection for vtol_dev_0.1

### DIFF
--- a/src/PositionManager/PositionManager.cpp
+++ b/src/PositionManager/PositionManager.cpp
@@ -135,7 +135,7 @@ void QGCPositionManager::_positionUpdated(const QGeoPositionInfo &update)
     // random heading to be shown on the fly view. So until we can get a true compass based heading or some smarted heading quality
     // information which takes into account the speed of movement we normally don't set a heading. We do use the heading though
     // if the plugin overrides the position source. In that case we assume that it hopefully know what it is doing.
-    if (_usingPluginSource && newGCSHeading != _gcsHeading) {
+    if ((_usingPluginSource || _trustGPSHeading) && newGCSHeading != _gcsHeading) {
         _gcsHeading = newGCSHeading;
         emit gcsHeadingChanged(_gcsHeading);
     }
@@ -199,4 +199,13 @@ void QGCPositionManager::setPositionSource(QGCPositionManager::QGCPositionSource
 void QGCPositionManager::_error(QGeoPositionInfoSource::Error positioningError)
 {
     qWarning() << "QGCPositionManager error" << positioningError;
+}
+
+void QGCPositionManager::setTrustGPSHeading(const bool trust) {
+    _trustGPSHeading = trust;
+
+    if(!_trustGPSHeading) {
+        _gcsHeading = qQNaN();
+        emit gcsHeadingChanged(_gcsHeading);
+    }
 }

--- a/src/PositionManager/PositionManager.h
+++ b/src/PositionManager/PositionManager.h
@@ -27,6 +27,8 @@ public:
 
     Q_PROPERTY(QGeoCoordinate gcsPosition  READ gcsPosition  NOTIFY gcsPositionChanged)
     Q_PROPERTY(qreal          gcsHeading   READ gcsHeading   NOTIFY gcsHeadingChanged)
+    Q_PROPERTY(bool           trustGPSHeading                READ trustGPSHeading
+                                                             WRITE setTrustGPSHeading)
     Q_PROPERTY(qreal          gcsPositionHorizontalAccuracy  READ gcsPositionHorizontalAccuracy
                                                              NOTIFY gcsPositionHorizontalAccuracyChanged)
 
@@ -39,6 +41,8 @@ public:
 
     QGeoCoordinate      gcsPosition         (void) { return _gcsPosition; }
     qreal               gcsHeading          (void) const{ return _gcsHeading; }
+    bool                trustGPSHeading     (void) const { return _trustGPSHeading; }
+    void                setTrustGPSHeading  (const bool trust);
     qreal               gcsPositionHorizontalAccuracy(void) const { return _gcsPositionHorizontalAccuracy; }
     QGeoPositionInfo    geoPositionInfo     (void) const { return _geoPositionInfo; }
     void                setPositionSource   (QGCPositionSource source);
@@ -64,6 +68,7 @@ private:
     QGeoPositionInfo    _geoPositionInfo;
     QGeoCoordinate      _gcsPosition;
     qreal               _gcsHeading =       qQNaN();
+    bool                _trustGPSHeading =  false;
     qreal               _gcsPositionHorizontalAccuracy = std::numeric_limits<qreal>::infinity();
 
     QGeoPositionInfoSource*     _currentSource =        nullptr;

--- a/src/Settings/AutoConnect.SettingsGroup.json
+++ b/src/Settings/AutoConnect.SettingsGroup.json
@@ -89,6 +89,13 @@
     "shortDesc": "Udp port to receive NMEA streams",
     "type":             "uint32",
     "default":     14401
+},
+{
+    "name":             "nmeaTrustHeading",
+    "shortDesc": "Extract heading from NMEA messages",
+    "longDesc":  "Extract heading from NMEA messages, this will extract heading from $RMC track",
+    "type":             "bool",
+    "default":     false
 }
 ]
 }

--- a/src/Settings/AutoConnectSettings.cc
+++ b/src/Settings/AutoConnectSettings.cc
@@ -23,6 +23,7 @@ DECLARE_SETTINGSFACT(AutoConnectSettings, udpListenPort)
 DECLARE_SETTINGSFACT(AutoConnectSettings, udpTargetHostIP)
 DECLARE_SETTINGSFACT(AutoConnectSettings, udpTargetHostPort)
 DECLARE_SETTINGSFACT(AutoConnectSettings, nmeaUdpPort)
+DECLARE_SETTINGSFACT(AutoConnectSettings, nmeaTrustHeading)
 
 DECLARE_SETTINGSFACT_NO_FUNC(AutoConnectSettings, autoConnectPixhawk)
 {

--- a/src/Settings/AutoConnectSettings.h
+++ b/src/Settings/AutoConnectSettings.h
@@ -38,4 +38,5 @@ public:
     DEFINE_SETTINGFACT(udpTargetHostIP)
     DEFINE_SETTINGFACT(udpTargetHostPort)
     DEFINE_SETTINGFACT(nmeaUdpPort)
+    DEFINE_SETTINGFACT(nmeaTrustHeading)
 };

--- a/src/Settings/Video.SettingsGroup.json
+++ b/src/Settings/Video.SettingsGroup.json
@@ -133,8 +133,8 @@
     "shortDesc":        "Force specific category of video decode",
     "longDesc":         "Force the change of prioritization between video decode methods, allowing the user to force some video hardware decode plugins if necessary.",
     "type":             "uint32",
-    "enumStrings":      "Default,Force software decoder,Force NVIDIA decoder,Force VA-API decoder,Force DirectX3D 11 decoder,Force VideoToolbox decoder",
-    "enumValues":       "0,1,2,3,4,5",
+    "enumStrings":      "Default,Force software decoder,Force NVIDIA decoder,Force VA-API decoder,Force DirectX3D 11 decoder,Force VideoToolbox decoder,Force V4L2 decoder",
+    "enumValues":       "0,1,2,3,4,5,6",
     "default":           0,
     "qgcRebootRequired": true
 }

--- a/src/Settings/VideoSettings.cc
+++ b/src/Settings/VideoSettings.cc
@@ -86,16 +86,19 @@ DECLARE_SETTINGGROUP(Video, "Video")
 #ifdef Q_OS_WIN
         VideoDecoderOptions::ForceVideoDecoderVAAPI,
         VideoDecoderOptions::ForceVideoDecoderVideoToolbox,
+        VideoDecoderOptions::ForceVideoDecoderRPiV4L2,
 #endif
 #ifdef Q_OS_MAC
         VideoDecoderOptions::ForceVideoDecoderDirectX3D,
         VideoDecoderOptions::ForceVideoDecoderVAAPI,
+        VideoDecoderOptions::ForceVideoDecoderRPiV4L2,
 #endif
 #ifdef Q_OS_ANDROID
         VideoDecoderOptions::ForceVideoDecoderDirectX3D,
         VideoDecoderOptions::ForceVideoDecoderVideoToolbox,
         VideoDecoderOptions::ForceVideoDecoderVAAPI,
         VideoDecoderOptions::ForceVideoDecoderNVIDIA,
+        VideoDecoderOptions::ForceVideoDecoderRPiV4L2,
 #endif
     };
 

--- a/src/Settings/VideoSettings.h
+++ b/src/Settings/VideoSettings.h
@@ -44,6 +44,7 @@ public:
         ForceVideoDecoderVAAPI,
         ForceVideoDecoderDirectX3D,
         ForceVideoDecoderVideoToolbox,
+        ForceVideoDecoderRPiV4L2,
     };
     Q_ENUM(VideoDecoderOptions)
 

--- a/src/VideoReceiver/GStreamer.cc
+++ b/src/VideoReceiver/GStreamer.cc
@@ -156,6 +156,9 @@ GStreamer::blacklist(VideoSettings::VideoDecoderOptions option)
         case VideoSettings::ForceVideoDecoderVideoToolbox:
             changeRank("vtdec", GST_RANK_PRIMARY + 1);
             break;
+        case VideoSettings::ForceVideoDecoderRPiV4L2:
+            changeRank("v4l2h264dec", GST_RANK_PRIMARY + 1);
+            break;
         default:
             qCWarning(GStreamerLog) << "Can't handle decode option:" << option;
     }

--- a/src/VideoReceiver/GstVideoReceiver.cc
+++ b/src/VideoReceiver/GstVideoReceiver.cc
@@ -928,8 +928,8 @@ GstVideoReceiver::_makeDecoder(GstCaps* caps, GstElement* videoSink)
     GstElement* decoder = nullptr;
 
     do {
-        if ((decoder = gst_element_factory_make("decodebin3", nullptr)) == nullptr) {
-            qCCritical(VideoReceiverLog) << "gst_element_factory_make('decodebin3') failed";
+        if ((decoder = gst_element_factory_make("decodebin", nullptr)) == nullptr) {
+            qCCritical(VideoReceiverLog) << "gst_element_factory_make('decodebin') failed";
             break;
         }
     } while(0);

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -519,7 +519,13 @@ void LinkManager::_updateAutoConnectLinks(void)
             _nmeaSocket.close();
             _nmeaSocket.bind(QHostAddress::AnyIPv4, _autoConnectSettings->nmeaUdpPort()->rawValue().toUInt());
             _toolbox->qgcPositionManager()->setNmeaSourceDevice(&_nmeaSocket);
+            _toolbox->qgcPositionManager()->setTrustGPSHeading(_autoConnectSettings->nmeaTrustHeading()->cookedValue().toBool());
         }
+
+        if(_autoConnectSettings->nmeaTrustHeading()->cookedValue().toBool() != _toolbox->qgcPositionManager()->trustGPSHeading()) {
+            _toolbox->qgcPositionManager()->setTrustGPSHeading(_autoConnectSettings->nmeaTrustHeading()->cookedValue().toBool());
+        }
+
         //close serial port
         if (_nmeaPort) {
             _nmeaPort->close();
@@ -580,6 +586,7 @@ void LinkManager::_updateAutoConnectLinks(void)
                 qCDebug(LinkManagerLog) << "Configuring nmea baudrate" << _nmeaBaud;
                 // This will stop polling old device if previously set
                 _toolbox->qgcPositionManager()->setNmeaSourceDevice(newPort);
+                _toolbox->qgcPositionManager()->setTrustGPSHeading(_autoConnectSettings->nmeaTrustHeading()->cookedValue().toBool());
                 if (_nmeaPort) {
                     delete _nmeaPort;
                 }
@@ -925,9 +932,9 @@ void LinkManager::_createDynamicForwardLink(const char* linkName, QString hostNa
 {
     UDPConfiguration* udpConfig = new UDPConfiguration(linkName);
     udpConfig->setDynamic(true);
-    
+
     udpConfig->addHost(hostName);
-    
+
     SharedLinkConfigurationPtr config = addConfiguration(udpConfig);
     createConnectedLink(config);
 

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -921,6 +921,16 @@ Rectangle {
                                     Layout.preferredWidth:  _valueFieldWidth
                                     fact:                   QGroundControl.settingsManager.autoConnectSettings.nmeaUdpPort
                                 }
+
+                                QGCLabel {
+                                    text:       qsTr("Trust NMEA Heading")
+                                    visible:    true
+                                }
+                                FactCheckBox {
+                                    visible:                true
+                                    Layout.preferredWidth:  _valueFieldWidth
+                                    fact:                   QGroundControl.settingsManager.autoConnectSettings.nmeaTrustHeading
+                                }
                             }
                         }
                     }

--- a/translations/qgc-json.ts
+++ b/translations/qgc-json.ts
@@ -87,7 +87,7 @@
     <message>
         <extracomment>.QGC.MetaData.Facts[forceVideoDecoder].enumStrings, </extracomment>
         <location filename="../src/Settings/Video.SettingsGroup.json"/>
-        <source>Default,Force software decoder,Force NVIDIA decoder,Force VA-API decoder,Force DirectX3D 11 decoder,Force VideoToolbox decoder</source>
+        <source>Default,Force software decoder,Force NVIDIA decoder,Force VA-API decoder,Force DirectX3D 11 decoder,Force VideoToolbox decoder,Force RPi V4L2 decoder</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
`vtol_dev_0.1` as checkpoint for development. Keeping `vtol_dev` clean until [bad_compass_changes](https://github.com/V-TOL-Aerospace/qgroundcontrol/tree/bad_compass_changes) and [custom_decoder_and_compass](https://github.com/V-TOL-Aerospace/qgroundcontrol/tree/custom_decoder_and_compass) can be better reviewed and cleaned. 